### PR TITLE
Convert plugin to Angular service

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'jest-preset-angular',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/*.spec.ts'],
+  setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }]
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,8 +1,22 @@
 {
   "name": "easy-modal-alert-box",
-  "version": "1.0.0",
-  "description": "Lightweight modal alert box component.",
+  "version": "2.0.0",
+  "description": "Lightweight modal alert box component as an Angular service.",
   "scripts": {
-    "test": "echo \"No tests\" && exit 0"
+    "test": "jest"
+  },
+  "dependencies": {
+    "@angular/common": "^16.2.0",
+    "@angular/core": "^16.2.0",
+    "rxjs": "^7.8.0",
+    "tslib": "^2.6.0",
+    "zone.js": "^0.13.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "jest": "^29.6.0",
+    "jest-preset-angular": "^13.0.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.2.0"
   }
 }

--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/src/easy-modal.service.spec.ts
+++ b/src/easy-modal.service.spec.ts
@@ -1,0 +1,33 @@
+import { TestBed } from '@angular/core/testing';
+import { DOCUMENT } from '@angular/common';
+import { EasyModalService, ModalConfig } from './easy-modal.service';
+
+describe('EasyModalService', () => {
+  let service: EasyModalService;
+  let document: Document;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(EasyModalService);
+    document = TestBed.inject(DOCUMENT);
+  });
+
+  afterEach(() => {
+    service.close();
+  });
+
+  it('should create modal with title and content', () => {
+    const config: ModalConfig = { title: 'Test', content: 'Hello' };
+    service.open(config);
+    const modal = document.querySelector('.easy-modal');
+    expect(modal).not.toBeNull();
+    expect(modal?.querySelector('.easy-modal-title')?.textContent).toBe('Test');
+    expect(modal?.querySelector('.easy-modal-content')?.innerHTML).toBe('Hello');
+  });
+
+  it('should remove modal on close', () => {
+    service.open({ title: 'Test', content: 'Bye' });
+    service.close();
+    expect(document.querySelector('.easy-modal')).toBeNull();
+  });
+});

--- a/src/easy-modal.service.ts
+++ b/src/easy-modal.service.ts
@@ -1,0 +1,117 @@
+import { Injectable, Inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+
+export interface ModalConfig {
+  title?: string;
+  content?: string;
+  autoOpen?: boolean;
+  type?: 'modal' | 'alert';
+  closeButton?: boolean;
+  closeText?: string;
+  maxWidth?: string;
+  minWidth?: string;
+  overlay?: boolean;
+  setTimeOut?: number | false;
+  overlayClass?: string;
+  modalTypeClass?: string[];
+  className?: string[];
+}
+
+const DEFAULT_CONFIG: Required<Omit<ModalConfig, 'setTimeOut' | 'modalTypeClass' | 'className'>> & {
+  setTimeOut: number | false;
+  modalTypeClass: string[];
+  className: string[];
+} = {
+  title: '',
+  content: '',
+  autoOpen: false,
+  type: 'modal',
+  closeButton: true,
+  closeText: 'X',
+  maxWidth: '',
+  minWidth: '',
+  overlay: true,
+  setTimeOut: false,
+  overlayClass: 'easy-modal-overlay',
+  modalTypeClass: ['error', 'info', 'warn', 'succes'],
+  className: []
+};
+
+@Injectable({ providedIn: 'root' })
+export class EasyModalService {
+  private modalEl: HTMLElement | null = null;
+  private overlayEl: HTMLElement | null = null;
+  private timeoutHandle: any;
+
+  constructor(@Inject(DOCUMENT) private document: Document) {}
+
+  open(config: ModalConfig): void {
+    const opts = { ...DEFAULT_CONFIG, ...config };
+    this.close();
+
+    if (opts.overlay) {
+      this.overlayEl = this.document.createElement('div');
+      this.overlayEl.classList.add(opts.overlayClass);
+      this.document.body.appendChild(this.overlayEl);
+    }
+
+    this.modalEl = this.document.createElement('div');
+    this.modalEl.classList.add('easy-modal');
+
+    if (opts.className.length) {
+      opts.className.forEach(c => this.modalEl!.classList.add(c));
+    }
+
+    if (opts.type === 'alert') {
+      opts.modalTypeClass.forEach(c => this.modalEl!.classList.add(c));
+    }
+
+    if (opts.maxWidth) {
+      this.modalEl.style.maxWidth = opts.maxWidth;
+    }
+    if (opts.minWidth) {
+      this.modalEl.style.minWidth = opts.minWidth;
+    }
+
+    if (opts.title) {
+      const titleEl = this.document.createElement('div');
+      titleEl.classList.add('easy-modal-title');
+      titleEl.textContent = opts.title;
+      this.modalEl.appendChild(titleEl);
+    }
+
+    const contentEl = this.document.createElement('div');
+    contentEl.classList.add('easy-modal-content');
+    contentEl.innerHTML = opts.content;
+    this.modalEl.appendChild(contentEl);
+
+    if (opts.closeButton) {
+      const button = this.document.createElement('button');
+      button.classList.add('easy-modal-close');
+      button.textContent = opts.closeText;
+      button.addEventListener('click', () => this.close());
+      this.modalEl.appendChild(button);
+    }
+
+    this.document.body.appendChild(this.modalEl);
+
+    if (typeof opts.setTimeOut === 'number' && opts.setTimeOut > 0) {
+      this.timeoutHandle = setTimeout(() => this.close(), opts.setTimeOut);
+    }
+  }
+
+  close(): void {
+    if (this.timeoutHandle) {
+      clearTimeout(this.timeoutHandle);
+      this.timeoutHandle = null;
+    }
+    if (this.modalEl && this.modalEl.parentNode) {
+      this.modalEl.parentNode.removeChild(this.modalEl);
+      this.modalEl = null;
+    }
+    if (this.overlayEl && this.overlayEl.parentNode) {
+      this.overlayEl.parentNode.removeChild(this.overlayEl);
+      this.overlayEl = null;
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest"],
+    "outDir": "dist-test"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- rework modal plugin into an Angular service with DOM-based open/close logic
- add Jest-based unit tests validating modal creation and cleanup
- configure TypeScript, Jest, and Angular dependencies for service package

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@angular%2fcommon)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689605f2de1c83238ec65b87e9ef210f